### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/src/follower.cpp
+++ b/src/follower.cpp
@@ -311,6 +311,6 @@ private:
   ros::Publisher bboxpub_;
 };
 
-PLUGINLIB_DECLARE_CLASS(oculusprime, OculusprimeFollower, oculusprime::OculusprimeFollower, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(oculusprime::OculusprimeFollower, nodelet::Nodelet)
 
 }


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions